### PR TITLE
 Change link of expired session to today's rather than tomorrow's session 

### DIFF
--- a/fuel/app/lang/en/session.php
+++ b/fuel/app/lang/en/session.php
@@ -135,7 +135,7 @@ return [
 		'link' => [
 			'enroll_first' => 'Be the first!',
 			'enroll_many' => 'Why don\'t you join them?',
-			'deadline_passed' => 'Enroll tomorrow?',
+			'deadline_passed' => 'Did you do the dishes?',
 			'no_cook' => 'Save the day, be a cook!',
 			'today' => 'View today\'s session',
 		]

--- a/fuel/app/lang/nl/session.php
+++ b/fuel/app/lang/nl/session.php
@@ -134,7 +134,7 @@ return [
 		'link' => [
 			'enroll_first' => 'Wees de eerste!',
 			'enroll_many' => 'Eet je mee?',
-			'deadline_passed' => 'Morgen inschrijven?',
+			'deadline_passed' => 'Heb jij afgewassen?',
 			'no_cook' => 'Red de dag, wees een kok!',
 			'today' => 'Laat de sessie zien',
 		]

--- a/fuel/app/modules/sessions/classes/controller/widget.php
+++ b/fuel/app/modules/sessions/classes/controller/widget.php
@@ -38,7 +38,7 @@ class Controller_Widget extends \Controller_Widget_Base {
 				$style = 'panel-grey';
 				$message = __('session.widget.msg.deadline_passed');
 				$link_text = __('session.widget.link.deadline_passed');
-				$link = '/sessions/tomorrow';
+				$link = '/sessions/today';
 			} 
 			
 		} else {


### PR DESCRIPTION
Currently, when you have done the dishes, you have to go to the (then already closed) session via the sessions button in the header, which adds an unnecessary action to the procedure. I would imagine very few people use the front-page widget to go to the session of tomorrow, so it might be changed to link to today's session, to make things easier for the ones who have done the dishes.